### PR TITLE
Bump ingress nginx controller image version

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
@@ -14,7 +14,7 @@ spec:
     imageRegistry: quay.io/opencloudio
     image:
       repository: nginx-ingress-controller
-      tag: 0.23.3
+      tag: 0.23.4
       pullPolicy: IfNotPresent
     resources:
       requests:

--- a/deploy/olm-catalog/ibm-ingress-nginx-operator/0.0.1/ibm-ingress-nginx-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-ingress-nginx-operator/0.0.1/ibm-ingress-nginx-operator.v0.0.1.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
               "image": {
                 "pullPolicy": "IfNotPresent",
                 "repository": "nginx-ingress-controller",
-                "tag": "0.23.3"
+                "tag": "0.23.4"
               },
               "name": "nginx-ingress-controller",
               "nodeSelector": {},

--- a/helm-charts/nginx-ingress/README.md
+++ b/helm-charts/nginx-ingress/README.md
@@ -129,7 +129,7 @@ The following table lists the configurable parameters of the `ICP Management Ing
 | ingress.httpPort                                | Listening http port of nginx backend                           | 80                              |
 | ingress.httpsPort                               | Listening https port of nginx backend                          | 443                             |
 | ingress.image.repository                        | NGINX Ingress Controller image to use for this deployment      | ibmcom/nginx-ingress-controller |
-| ingress.image.tag                               | NGINX Ingress Controller image tag to use for this deployment  | 0.23.2                          |
+| ingress.image.tag                               | NGINX Ingress Controller image tag to use for this deployment  | 0.23.4                          |
 | ingress.image.pullPolicy                        | NGINX Ingress Controller image pull policy                     | IfNotPresent                    |
 | ingress.resources.requests.cpu                  | cpu request to run this deployment                             | 50m                             |
 | ingress.resources.requests.memory               | memory request to run this deployment                          | 256Mi                           |

--- a/helm-charts/nginx-ingress/RELEASENOTES.md
+++ b/helm-charts/nginx-ingress/RELEASENOTES.md
@@ -7,7 +7,7 @@ The chart is now available as verson 3.5.0
 | 3.5.0 | Oct 2019 | |
 
 # Fixes
-- upgrade nginx-ingress-controller to version 0.23.2
+- upgrade nginx-ingress-controller to version 0.23.4
 
 # Prerequisites
 - OCP 3.11

--- a/helm-charts/nginx-ingress/ibm_cloud_pak/manifest.yaml
+++ b/helm-charts/nginx-ingress/ibm_cloud_pak/manifest.yaml
@@ -6,20 +6,20 @@ charts:
       - init.image.repository
 
 images:
-- image: ibmcom/nginx-ingress-controller:0.23.2
+- image: ibmcom/nginx-ingress-controller:0.23.4
   references:
-  - repository: ibmcom/nginx-ingress-controller-amd64:0.23.2
-    pull-repository: ibmcom/nginx-ingress-controller:0.23.2-amd64
+  - repository: ibmcom/nginx-ingress-controller-amd64:0.23.4
+    pull-repository: ibmcom/nginx-ingress-controller:0.23.4-amd64
     platform:
       os: linux
       architecture: amd64
-  - repository: ibmcom/nginx-ingress-controller-ppc64le:0.23.2
-    pull-repository: ibmcom/nginx-ingress-controller:0.23.2-ppc64le
+  - repository: ibmcom/nginx-ingress-controller-ppc64le:0.23.4
+    pull-repository: ibmcom/nginx-ingress-controller:0.23.4-ppc64le
     platform:
       os: linux
       architecture: ppc64le
-  - repository: ibmcom/nginx-ingress-controller-s390x:0.23.2
-    pull-repository: ibmcom/nginx-ingress-controller:0.23.2-s390x
+  - repository: ibmcom/nginx-ingress-controller-s390x:0.23.4
+    pull-repository: ibmcom/nginx-ingress-controller:0.23.4-s390x
     platform:
       os: linux
       architecture: s390x

--- a/helm-charts/nginx-ingress/values.yaml
+++ b/helm-charts/nginx-ingress/values.yaml
@@ -16,7 +16,7 @@ ingress:
   imageRegistry: quay.io/opencloudio
   image:
     repository: nginx-ingress-controller
-    tag: 0.23.3
+    tag: 0.23.4
     pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Version 0.23.3 was already used in previous release. So bump
the image version for the current release.