### PR TITLE
Delete route route first before create new one

### DIFF
--- a/helm-charts/nginx-ingress/templates/script-configmap.yaml
+++ b/helm-charts/nginx-ingress/templates/script-configmap.yaml
@@ -36,6 +36,9 @@ data:
     HOST="${NAME}.$appDomain"
     cp /opt/ingress-nginx/config/cp-proxy-route.yaml /opt/ingress-nginx/data/
 
+    echo "Trying to delete the route ${NAME} first."
+    kubectl -n ${NAMESPACE} delete -f /opt/ingress-nginx/data/cp-proxy-route.yaml
+
     echo "Creating route ${NAME} to have correct host: ${HOST}."
     sed -i 's/host: cp-proxy.apps.ibm.com/host: "'$HOST'"/g' /opt/ingress-nginx/data/cp-proxy-route.yaml
     kubectl -n ${NAMESPACE} apply -f /opt/ingress-nginx/data/cp-proxy-route.yaml


### PR DESCRIPTION
Because of limitation that route resource will not be removed
when helm release was deleted it needs to delete the route first
to handle reinstallation case.