### PR TITLE
Add resource limits for the operand pod

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
@@ -19,7 +19,10 @@ spec:
     resources:
       requests:
         cpu: 50m
-        memory: 256Mi 
+        memory: 150Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
     config:
       disable-access-log: 'true'
       keep-alive-requests: '10000'
@@ -39,6 +42,9 @@ spec:
       pullPolicy: IfNotPresent
     resources:
       requests:
+        cpu: 20m
+        memory: 64Mi
+      limits:
         cpu: 20m
         memory: 64Mi
     nodeSelector: {}

--- a/deploy/olm-catalog/ibm-ingress-nginx-operator/0.0.1/ibm-ingress-nginx-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-ingress-nginx-operator/0.0.1/ibm-ingress-nginx-operator.v0.0.1.clusterserviceversion.yaml
@@ -25,6 +25,10 @@ metadata:
                 "requests": {
                   "cpu": "20m",
                   "memory": "64Mi"
+                },
+                "limits": {
+                  "cpu": "20m",
+                  "memory": "64Mi"
                 }
               },
               "tolerations": []
@@ -55,6 +59,10 @@ metadata:
               "resources": {
                 "requests": {
                   "cpu": "50m",
+                  "memory": "150Mi"
+                },
+                "limits": {
+                  "cpu": "200m",
                   "memory": "256Mi"
                 }
               },

--- a/helm-charts/nginx-ingress/templates/job.yaml
+++ b/helm-charts/nginx-ingress/templates/job.yaml
@@ -56,6 +56,7 @@ spec:
         resources:
           requests:
             memory: "32Mi"
+            cpu: "50m"
           limits:
             memory: "128Mi"
             cpu: "200m"

--- a/helm-charts/nginx-ingress/values.yaml
+++ b/helm-charts/nginx-ingress/values.yaml
@@ -26,6 +26,9 @@ ingress:
   resources:
     requests:
       cpu: 50m
+      memory: 150Mi
+    limits:
+      cpu: 200m
       memory: 256Mi
   config:
     disable-access-log: 'true'
@@ -49,6 +52,9 @@ defaultBackend:
     pullPolicy: IfNotPresent
   resources:
     requests:
+      cpu: 20m
+      memory: 64Mi
+    limits:
       cpu: 20m
       memory: 64Mi
   nodeSelector: {}


### PR DESCRIPTION
Add resource limits for the ingress nginx controller and default http
backend pod based on some presure test.