### PR TITLE
Change priority of scc to the lowest

### DIFF
--- a/helm-charts/nginx-ingress/templates/scc.yaml
+++ b/helm-charts/nginx-ingress/templates/scc.yaml
@@ -8,7 +8,7 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: nginx-ingress-scc
-priority: 10
+priority: 1
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false


### PR DESCRIPTION
There is conflict with OCP default scc ((e.g., anyuid). For example,
if some of OCP pods were restarted it will by default select the
strict one with same priority. But the ingress nginx scc does not
allow run container with root user, which is not case for some of
OCP pods. Change the priority of scc to the lowest will fix this issue.