### PR TITLE
Update image version for 2020 Q2 release

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_nginxingress_cr.yaml
@@ -14,7 +14,7 @@ spec:
     imageRegistry: quay.io/opencloudio
     image:
       repository: nginx-ingress-controller
-      tag: 0.23.4
+      tag: 0.23.5
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -38,7 +38,7 @@ spec:
     image:
       imageRegistry: quay.io/opencloudio
       repository: default-http-backend
-      tag: 1.5.3
+      tag: 1.5.4
       pullPolicy: IfNotPresent
     resources:
       requests:
@@ -53,7 +53,7 @@ spec:
     imageRegistry: quay.io/opencloudio
     image:
       repository: icp-initcontainer
-      tag: 1.0.0-build.2
+      tag: 1.0.0-build.4
       pullPolicy: IfNotPresent
   kubectl:
     resources:
@@ -66,5 +66,5 @@ spec:
     imageRegistry: quay.io/opencloudio
     image:
       repository: kubectl
-      tag: v1.15.9
+      tag: v1.15.9.1
   fips_enabled: false

--- a/deploy/olm-catalog/ibm-ingress-nginx-operator/1.2.0/ibm-ingress-nginx-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-ingress-nginx-operator/1.2.0/ibm-ingress-nginx-operator.v1.2.0.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
               "image": {
                 "pullPolicy": "IfNotPresent",
                 "repository": "default-http-backend",
-                "tag": "1.5.3"
+                "tag": "1.5.4"
               },
               "name": "default-http-backend",
               "nodeSelector": {},
@@ -51,7 +51,7 @@ metadata:
               "image": {
                 "pullPolicy": "IfNotPresent",
                 "repository": "nginx-ingress-controller",
-                "tag": "0.23.4"
+                "tag": "0.23.5"
               },
               "name": "nginx-ingress-controller",
               "nodeSelector": {},
@@ -74,7 +74,7 @@ metadata:
               "image": {
                 "pullPolicy": "IfNotPresent",
                 "repository": "icp-initcontainer",
-                "tag": "1.0.0-build.2"
+                "tag": "1.0.0-build.4"
               }
             },
             "kubectl": {
@@ -91,7 +91,7 @@ metadata:
               "imageRegistry": "quay.io/opencloudio",
               "image": {
                 "repository": "kubectl",
-                "tag": "v1.15.9"
+                "tag": "v1.15.9.1"
               }
             }
           }

--- a/helm-charts/nginx-ingress/Chart.yaml
+++ b/helm-charts/nginx-ingress/Chart.yaml
@@ -1,4 +1,4 @@
-appVersion: 3.5.0
+appVersion: 3.6.0
 description: Ingress Controller for IBM Cloud Private
 home: https://github.com/kubernetes/ingress
 icon: https://raw.githubusercontent.com/kubernetes/kubernetes/master/logo/logo.png

--- a/helm-charts/nginx-ingress/values.yaml
+++ b/helm-charts/nginx-ingress/values.yaml
@@ -21,7 +21,7 @@ ingress:
   imageRegistry: quay.io/opencloudio
   image:
     repository: nginx-ingress-controller
-    tag: 0.23.4
+    tag: 0.23.5
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -48,7 +48,7 @@ defaultBackend:
   imageRegistry: quay.io/opencloudio
   image:
     repository: default-http-backend
-    tag: 1.5.3
+    tag: 1.5.4
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -65,7 +65,7 @@ init:
   imageRegistry: quay.io/opencloudio
   image:
     repository: icp-initcontainer
-    tag: 1.0.0-build.2
+    tag: 1.0.0-build.4
     pullPolicy: IfNotPresent
 
 # The kubectl image used to patch route resource
@@ -80,4 +80,4 @@ kubectl:
   imageRegistry: quay.io/opencloudio
   image:
     repository: kubectl
-    tag: v1.15.9
+    tag: v1.15.9.1


### PR DESCRIPTION
Images in CSV and chart are still refering to version used in
previous release. Update the image version for Common Service
2020 Q2 release.