### PR TITLE
Fix upgrade issue no enough permission

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -15,6 +15,8 @@ rules:
   - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security.openshift.io
@@ -26,6 +28,7 @@ rules:
   - get
   - use
   - patch
+  - update
 - apiGroups:
   - certmanager.k8s.io
   resources:

--- a/deploy/olm-catalog/ibm-ingress-nginx-operator/1.2.0/ibm-ingress-nginx-operator.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-ingress-nginx-operator/1.2.0/ibm-ingress-nginx-operator.v1.2.0.clusterserviceversion.yaml
@@ -154,6 +154,8 @@ spec:
           - delete
           - get
           - list
+          - patch
+          - update
           - watch
         - apiGroups:
           - security.openshift.io
@@ -165,6 +167,7 @@ spec:
           - get
           - use
           - patch
+          - update
         - apiGroups:
           - certmanager.k8s.io
           resources:


### PR DESCRIPTION
Helm operator failed to replace scc object of operand in the case
of upgrade. It just does not have enough permission to update
scc. This fix just adds the required permission.