### PR TITLE
fix inconsistent user.

### DIFF
--- a/helm-charts/nginx-ingress/templates/post-upgrade-job.yaml
+++ b/helm-charts/nginx-ingress/templates/post-upgrade-job.yaml
@@ -40,8 +40,6 @@ spec:
       hostNetwork: false
       hostPID: false
       hostIPC: false
-      securityContext:
-        runAsNonRoot: true
       serviceAccount: nginx-ingress-serviceaccount
       containers:
       - name: kubectl
@@ -68,7 +66,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
           capabilities:
             drop:
             - ALL

--- a/helm-charts/nginx-ingress/templates/pre-delete-job.yaml
+++ b/helm-charts/nginx-ingress/templates/pre-delete-job.yaml
@@ -40,8 +40,6 @@ spec:
       hostNetwork: false
       hostPID: false
       hostIPC: false
-      securityContext:
-        runAsNonRoot: true
       serviceAccount: nginx-ingress-serviceaccount
       containers:
       - name: pre-delete-job
@@ -64,7 +62,6 @@ spec:
           privileged: false
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
Fix error:
```
Error: container has runAsNonRoot and image has non-numeric user (kubectl), cannot verify user is non-root
```